### PR TITLE
saving upgrade rooms

### DIFF
--- a/source/models/Relic.cpp
+++ b/source/models/Relic.cpp
@@ -64,12 +64,10 @@ void Relic::setActive(bool active) {
 void Relic::draw(const std::shared_ptr<cugl::SpriteBatch> &batch){
     if (_texture != nullptr){
         Vec2 origin(_texture->getWidth()/2, 0);
-        auto spriteSheet = _currAnimation->getSpriteSheet();
-        Affine2 aniTransform = Affine2::createTranslation(_position * _drawScale);
-        
         batch->draw(_texture, origin, _size * _drawScale / _texture->getSize(), 0, _position * _drawScale);
-        
-        if (!_currAnimation->isCompleted()){
+        if (_currAnimation != nullptr && !_currAnimation->isCompleted()){
+            auto spriteSheet = _currAnimation->getSpriteSheet();
+            Affine2 aniTransform = Affine2::createTranslation(_position * _drawScale);
             spriteSheet->draw(batch, origin, aniTransform);
         }
     }

--- a/source/scenes/GameScene.cpp
+++ b/source/scenes/GameScene.cpp
@@ -139,22 +139,34 @@ bool GameScene::init(const std::shared_ptr<AssetManager>& assets) {
     _levelTransition.setFadeIn(GameConstants::TRANSITION_FADE_IN_TIME);
     _levelTransition.setFadeOut(GameConstants::TRANSITION_FADE_OUT_TIME, Color4(255, 255, 255, 0));
     _levelTransition.setFadeInCallBack([this](){
+        if (_isTutorial){
+            _isTutorialComplete = true; // this flags allows switching to tutorial menu
+            return;
+        }
+        
+        SaveData::Data data;
+        auto p = _level->getPlayer();
+        bool upgradeAvailable = false;
         if (_isUpgradeRoom){
             // current room was upgrades, just go to the current level number
             _isUpgradeRoom = false;
-        } 
-        else if (_isTutorial){
-            _isTutorialComplete = true; // this flags allows switching to tutorial menu
-            return;
         }
         else {
             this->_levelNumber+=1;
             this->_isUpgradeRoom = _levelNumber % 3 == 1; // check if an upgrades room should be offered before the next level
+            if (_isUpgradeRoom){
+                upgradeAvailable = true;
+                // generate random new upgrades
+                std::pair<std::pair<int, int>, std::pair<int, int>> indices = generateUpgradeIndices(p);
+                data.upgradeOpt1 = indices.first.first;
+                data.upgradeOpt1Level = indices.first.second;
+                data.upgradeOpt2 = indices.second.first;
+                data.upgradeOpt2Level = indices.second.second;
+            }
         }
-        
         // save game data as level ends
-        auto p = _level->getPlayer();
-        SaveData::Data data;
+        data.isUpgradeRoom = _isUpgradeRoom;
+        data.upgradeAvailable = upgradeAvailable;
         data.level = _levelNumber;
         data.hp = p->getHP();
         data.atkLvl = p->getMeleeUpgrade().getCurrentLevel();
@@ -197,7 +209,6 @@ void GameScene::activateTutorial(int level){
     _levelTransition.setActive(false);
     setTutorialActive(true);
     _exitCode = NONE;
-    _isUpgradeRoom = false;
     SaveData::Data data;
     data.level = level;
     data.hp = GameConstants::PLAYER_MAX_HP;
@@ -206,11 +217,19 @@ void GameScene::activateTutorial(int level){
 
 void GameScene::restart(){
     _levelTransition.setActive(false);
-    _isUpgradeRoom = true;  // first level is always upgrades
     SaveData::removeSave();
     SaveData::Data data;
     data.level = 1;
+    data.isUpgradeRoom = true; // first level is always upgrades
+    data.upgradeAvailable = true;
+    // pick two random upgrades
+    std::pair<std::pair<int, int>, std::pair<int, int>> indices = generateUpgradeIndices(nullptr);
+    data.upgradeOpt1 = indices.first.first;
+    data.upgradeOpt1Level = indices.first.second;
+    data.upgradeOpt2 = indices.second.first;
+    data.upgradeOpt2Level = indices.second.second;
     data.hp = GameConstants::PLAYER_MAX_HP;
+    SaveData::makeSave(data);
     setLevel(data);
 }
 
@@ -220,6 +239,7 @@ void GameScene::setLevel(SaveData::Data saveData){
     std::string levelToParse;
     auto level = saveData.level;
     _levelNumber = level;
+    _isUpgradeRoom = saveData.isUpgradeRoom;
     _upgrades.setActive(false);
     if (_isUpgradeRoom){
         levelToParse = "upgrades";
@@ -263,13 +283,20 @@ void GameScene::setLevel(SaveData::Data saveData){
     _camController.setCamPosition(p->getPosition() * p->getDrawScale());
     
     if (_isUpgradeRoom) {
-        _level->getRelic()->setActive(true);
+        if (saveData.upgradeAvailable){
+            _level->getRelic()->setActive(true);
+            std::array<Upgradeable, 7> upgradeOptions = getPlayerUpgrades(p);
+            int idx1 = saveData.upgradeOpt1;
+            int idx2 = saveData.upgradeOpt2;
+            upgradeOptions[idx1].setCurrentLevel(saveData.upgradeOpt1Level);
+            upgradeOptions[idx2].setCurrentLevel(saveData.upgradeOpt2Level);
+            _upgrades.updateScene({upgradeOptions[idx1], upgradeOptions[idx2]});
+        }
         // turn off the energy walls first
         auto energyWalls = _level->getEnergyWalls();
         for (auto it = energyWalls.begin(); it != energyWalls.end(); ++it) {
             (*it)->deactivate();
         }
-        configureUpgradeMenu(p);
     }
     
     setComplete(false);
@@ -291,15 +318,42 @@ void GameScene::setLevel(SaveData::Data saveData){
     _deadEffectNode->setVisible(false);
 }
 
-void GameScene::configureUpgradeMenu(std::shared_ptr<Player> player){
-    // first find the stats that can be upgraded
-    std::array<Upgradeable, 7> all = {
+std::array<Upgradeable, 7> GameScene::getPlayerUpgrades(std::shared_ptr<Player> player){
+    std::array<Upgradeable, 7> upgradeOptions = {
         player->getMeleeUpgrade(), player->getMeleeSpeedUpgrade(), player->getBowUpgrade(), player->getHPUpgrade(), player->getStunUpgrade(), player->getDodgeUpgrade(), player->getDamageReductionUpgrade()};
-    std::vector<Upgradeable> options;
-    for (Upgradeable& upgrade : all){
-        if (!upgrade.isMaxLevel()){
-            options.push_back(upgrade);
+    return upgradeOptions;
+}
+
+std::pair<std::pair<int,int>, std::pair<int,int>> GameScene::generateUpgradeIndices(std::shared_ptr<Player> player){
+    std::vector<int> options;
+    std::vector<int> levels;
+    if (player != nullptr){
+        // first find the stats that can be upgraded
+        std::array<Upgradeable, 7> upgradeOptions = getPlayerUpgrades(player);
+        for (int i = 0; i < 7; i++){
+            Upgradeable u = upgradeOptions[i];
+            if (!u.isMaxLevel()){
+                options.push_back(i);
+                levels.push_back(std::min(u.getCurrentLevel() + 1, u.getMaxLevel()));
+            }
         }
+        
+        if (options.size() == 1){
+            // duplicate, since only 1 thing to upgrade
+            options.push_back(options[0]);
+            levels.push_back(levels[0]);
+        }
+        else if (options.size() == 0){
+            // anything will work, nothing to upgrade
+            options.push_back(0);
+            options.push_back(1);
+            levels.push_back(upgradeOptions[0].getCurrentLevel());
+            levels.push_back(upgradeOptions[1].getCurrentLevel());
+        }
+    }
+    else {
+        options = {0, 1, 2, 3, 4, 5, 6};
+        levels = {1, 1, 1, 1, 1, 1, 1};
     }
     int opt1 = 0;
     int opt2 = 1;
@@ -310,21 +364,10 @@ void GameScene::configureUpgradeMenu(std::shared_ptr<Player> player){
             opt2 = std::rand() % options.size();
         }
     }
-    else if (options.size() == 1){
-        // duplicate
-        options.push_back(options[0]);
-    }
-    else if (options.size() == 0){
-        // anything will work, nothing to upgrade
-        Upgradeable u1 = all[0];
-        u1.setCurrentLevel(u1.getMaxLevel() - 1);
-        Upgradeable u2 = all[1];
-        u2.setCurrentLevel(u2.getMaxLevel() - 1);
-        options.push_back(u1);
-        options.push_back(u2);
-    }
-    std::pair<Upgradeable, Upgradeable> randomOptions(options[opt1], options[opt2]);
-    _upgrades.updateScene(randomOptions);
+    std::pair<int, int> random1(options[opt1], levels[opt1]);
+    std::pair<int, int> random2(options[opt2], levels[opt2]);
+    std::pair<std::pair<int, int>, std::pair<int, int>> randomOptions(random1, random2);
+    return randomOptions;
 }
 
 std::vector<int> GameScene::getPlayerLevels(){
@@ -703,35 +746,49 @@ void GameScene::preUpdate(float dt) {
         auto relic = _level->getRelic();
         _upgrades.setActive(relic->getTouched() && relic->getActive());
         if (_upgrades.isActive() && _upgrades.hasSelectedUpgrade()){
+            // get current save, make new save based on selection
+            SaveData::Data data = SaveData::getGameSave();
+            data.upgradeAvailable = false;
+            data.weapon = player->getWeapon(); // easy to forget the weapon changes constantly
             // get the selected upgrade, apply to player
             float prevMaxHP = player->getMaxHP();
+            int newLevel = _upgrades.getUpgradeLevel();
             switch (_upgrades.getChoice()) {
                 case UpgradeType::SWORD:
-                    player->setMeleeLevel(_upgrades.getUpgradeLevel());
+                    player->setMeleeLevel(newLevel);
+                    data.atkLvl = newLevel;
                     break;
                 case PARRY:
-                    player->setStunLevel(_upgrades.getUpgradeLevel());
+                    player->setStunLevel(newLevel);
+                    data.parryLvl = newLevel;
                     break;
                 case ATK_SPEED:
-                    player->setMeleeSpeedLevel(_upgrades.getUpgradeLevel());
+                    player->setMeleeSpeedLevel(newLevel);
+                    data.atkSpLvl = newLevel;
                     break;
                 case DASH:
-                    player->setDodgeLevel(_upgrades.getUpgradeLevel());
+                    player->setDodgeLevel(newLevel);
+                    data.dashLvl = newLevel;
                     break;
                 case UpgradeType::BOW:
-                    player->setBowLevel(_upgrades.getUpgradeLevel());
+                    player->setBowLevel(newLevel);
+                    data.rangedLvl = newLevel;
                     break;
                 case HEALTH:
-                    player->setMaxHPLevel(_upgrades.getUpgradeLevel());
+                    player->setMaxHPLevel(newLevel);
                     player->setHP(player->getHP() + player->getMaxHP() - prevMaxHP);
+                    data.hpLvl = newLevel;
+                    data.hp = player->getHP();
                     break;
                 case SHIELD: case BLOCK:
                     player->setArmorLevel(_upgrades.getUpgradeLevel());
                     player->setBlockLevel(_upgrades.getUpgradeLevel());
+                    data.defLvl = newLevel;
                     break;
             }
             // turn off relic
             relic->setActive(false);
+            SaveData::makeSave(data);
         }
     }
 }

--- a/source/scenes/GameScene.hpp
+++ b/source/scenes/GameScene.hpp
@@ -14,6 +14,7 @@
 #include <cugl/cugl.h>
 #include <box2d/b2_world_callbacks.h>
 #include <vector>
+#include <array>
 #include "../models/Player.hpp"
 #include "../controllers/AIController.hpp"
 #include "../controllers/AudioController.hpp"
@@ -81,10 +82,17 @@ protected:
     TransitionScene _levelTransition;
     /** the upgrades menu  */
     UpgradesScene _upgrades;
+    
     /**
-     * sets up the upgrade scene based on player stats, picking random stats to be upgraded.
+     * @note the order is irrelevant. The function `generateUpgradeIndices` make up for this lack of specification.
+     * @return the list of current upgrades for the given player
      */
-    void configureUpgradeMenu(std::shared_ptr<Player> player);
+    std::array<Upgradeable, 7> getPlayerUpgrades(std::shared_ptr<Player> player);
+    /**
+     * @note if `player` is a null pointer, the entire set of upgrades are valid and implies that there are no current upgrades.
+     * @return a pair of pairs of (indices, level) indicating the two upgrades to be shown in upgrade scene.
+     */
+    std::pair<std::pair<int,int>, std::pair<int,int>> generateUpgradeIndices(std::shared_ptr<Player> player);
 
 #pragma mark Scene Nodes
     /** Reference to the physics node of this scene graph */

--- a/source/scenes/UpgradesScene.cpp
+++ b/source/scenes/UpgradesScene.cpp
@@ -213,10 +213,10 @@ void UpgradesScene::setButtonText(UpgradeType upgrade, int level, int buttonType
 
 void UpgradesScene::updateScene(std::pair<Upgradeable, Upgradeable> upgradeOptions){
     _displayedAttribute1.first = upgradeOptions.first.getType();
-    _displayedAttribute1.second = upgradeOptions.first.getCurrentLevel() + 1;
+    _displayedAttribute1.second = upgradeOptions.first.getCurrentLevel();
     
     _displayedAttribute2.first = upgradeOptions.second.getType();
-    _displayedAttribute2.second = upgradeOptions.second.getCurrentLevel() + 1;
+    _displayedAttribute2.second = upgradeOptions.second.getCurrentLevel();
     
     setButtonText(_displayedAttribute1.first, _displayedAttribute1.second, 0);
     setButtonText(_displayedAttribute2.first, _displayedAttribute2.second, 1);

--- a/source/utility/SaveData.cpp
+++ b/source/utility/SaveData.cpp
@@ -38,14 +38,19 @@ bool SaveData::hasGameSave(){
     dataCache.hp = hp;
     dataCache.level = json->getInt("level", 1);
     dataCache.weapon = json->getInt("weapon");
-    dataCache.hpLvl = json->getInt("hpLvl");
-    dataCache.atkLvl = json->getInt("atkLvl");
-    dataCache.atkSpLvl = json->getInt("atkSpLvl");
-    dataCache.rangedLvl = json->getInt("rangedLvl");
-    dataCache.defLvl = json->getInt("defLvl");
-    dataCache.parryLvl = json->getInt("parryLvl");
-    dataCache.dashLvl = json->getInt("dashLvl");
-    //TODO: maybe do post-processing to constraint within [0,5] for each level
+    dataCache.hpLvl = constraint(json->getInt("hpLvl"), 0, 5);
+    dataCache.atkLvl = constraint(json->getInt("atkLvl"), 0, 5);
+    dataCache.atkSpLvl = constraint(json->getInt("atkSpLvl"), 0, 5);
+    dataCache.rangedLvl = constraint(json->getInt("rangedLvl"), 0, 5);
+    dataCache.defLvl = constraint(json->getInt("defLvl"), 0, 5);
+    dataCache.parryLvl = constraint(json->getInt("parryLvl"), 0, 5);
+    dataCache.dashLvl = constraint(json->getInt("dashLvl"), 0, 5);
+    dataCache.isUpgradeRoom = json->getBool("up", false);
+    dataCache.upgradeAvailable = json->getBool("available", false);
+    dataCache.upgradeOpt1 = json->getInt("opt1", 0);
+    dataCache.upgradeOpt2 = json->getInt("opt2", 0);
+    dataCache.upgradeOpt1Level = constraint(json->getInt("opt1level"), 0, 5);
+    dataCache.upgradeOpt2Level = constraint(json->getInt("opt2level"), 0, 5);
     reader->close();
     return true;
 }
@@ -67,6 +72,14 @@ void SaveData::makeSave(Data data){
     json->appendChild("defLvl", JsonValue::alloc((long)data.defLvl));
     json->appendChild("parryLvl", JsonValue::alloc((long)data.parryLvl));
     json->appendChild("dashLvl", JsonValue::alloc((long)data.dashLvl));
+    // upgrade room info
+    json->appendChild("up", JsonValue::alloc((data.isUpgradeRoom)));
+    json->appendChild("available", JsonValue::alloc(data.upgradeAvailable));
+    json->appendChild("opt1", JsonValue::alloc((long)data.upgradeOpt1));
+    json->appendChild("opt1level", JsonValue::alloc((long)data.upgradeOpt1Level));
+    json->appendChild("opt2", JsonValue::alloc((long)data.upgradeOpt2));
+    json->appendChild("opt2level", JsonValue::alloc((long)data.upgradeOpt2Level));
+    
     auto path = Application::get()->getSaveDirectory() + SAVEFILE;
     CULog("savefile %s", std::string(path).c_str());
     auto writer = JsonWriter::alloc(path);

--- a/source/utility/SaveData.hpp
+++ b/source/utility/SaveData.hpp
@@ -23,7 +23,6 @@ public:
      * player data (with attributes default to 0)
      */
     struct Data {
-        // TODO: add other fields as needed
         /** the level to load on start */
         int level;
         /** player current HP */
@@ -37,6 +36,13 @@ public:
         int defLvl = 0;
         int parryLvl = 0;
         int dashLvl = 0;
+        /** whether this room has an available upgrade before the given level*/
+        bool isUpgradeRoom = false;
+        bool upgradeAvailable = false;
+        int upgradeOpt1 = 0;
+        int upgradeOpt1Level = 1;
+        int upgradeOpt2 = 0;
+        int upgradeOpt2Level = 1;
     };
     
     struct Preferences {
@@ -64,6 +70,13 @@ private:
     static std::shared_ptr<JsonValue> prefsJson;
     /** struct cache object for player preferences */
     static Preferences prefsCache;
+    
+    /**
+     * @returns the given value clipped inside the given extremes
+     */
+    static int constraint(int value, int low, int high){
+        return value > high ? high : (value < low ? low : value);
+    }
 
 public:
 #pragma mark - Game Related Saves


### PR DESCRIPTION
- allow users to leave and return in the upgrade room with the same upgrade options shown to them
- (can be removed), game saves when user selects options from the upgrade system